### PR TITLE
Separate prod/local environments

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -13,19 +13,15 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), ".."
+)
 
 #static files
 STATICFILES_DIRS = ['%s/static' % BASE_DIR, '/static/']
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '@yk=67ph&l8t%(4zhfjd8cla2@c)*26n)5#8ebn_m33*b4zi67'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -72,18 +68,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'cfp.db'),
-    }
-}
-
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators

--- a/settings/local.py
+++ b/settings/local.py
@@ -1,0 +1,22 @@
+from .base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '@yk=67ph&l8t%(4zhfjd8cla2@c)*26n)5#8ebn_m33*b4zi67'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'cfp.db'),
+    }
+}
+
+INSTALLED_APPS += (
+    'debug_toolbar',
+)
+
+MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]

--- a/settings/production.py
+++ b/settings/production.py
@@ -1,0 +1,16 @@
+import os
+from .base import *
+
+DEBUG = False
+SECRET_KEY = os.environ['SECRET_KEY']
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'pybay',
+        'USER': 'pybay',
+        'PASSWORD': os.environ['DB_PASSWD'],
+        'HOST': 'localhost',
+        'PORT': '',
+    }
+}


### PR DESCRIPTION
In order to avoid leaking credentials + having a candid separation of environments, I have separated the environments to be distinct.

When you develop locally, you should always specify the `local` settings environment. Example: say you want to run a local server, then the command to run is:
```
python manage.py runserver --settings=settings.local
```